### PR TITLE
fix: validate suggested amounts against min.

### DIFF
--- a/wc-nyp-suggested-amounts.php
+++ b/wc-nyp-suggested-amounts.php
@@ -235,6 +235,9 @@ class WC_NYP_Suggested_Amounts {
 
 		if ( isset( $_POST['wc_nyp_use_suggested_amounts'] ) ) {
 			$product->update_meta_data( '_wc_nyp_use_suggested_amounts', 'yes' );
+
+			// Delete the default _suggested_amount to avoid conflict.
+			$product->delete_meta_data( '_suggested_price' );
 		} else {
 			$product->delete_meta_data( '_wc_nyp_use_suggested_amounts' );
 		}
@@ -373,3 +376,4 @@ class WC_NYP_Suggested_Amounts {
 
 }
 add_action( 'plugins_loaded', array( 'WC_NYP_Suggested_Amounts', 'init' ), 99 );
+ 


### PR DESCRIPTION
This will be irrelevant If we want to merge suggested amounts to the main suggested price feature.
> The biggest complexity is that the core plugin has a _suggested_price meta field. And I think we should eliminate the toggle that is added in the mini-extension and always use the mini-extension's admin UI for adding suggested prices. The mini-extension though has a different meta key that's an array _suggested_amounts.  So the biggest thing is that needs to be unified and we need to determine if an upgrade routine is required of if we can work around that.
